### PR TITLE
Fix typo in CS231N teaching description

### DIFF
--- a/archive.html
+++ b/archive.html
@@ -108,7 +108,7 @@
       <section>
         <h3>CS231N: Convolutional Neural Networks for Visual Recognition</h3>
         <p>Teaching Assistant, <a href="http://cs231n.stanford.edu/">Spring 2018</a></p>
-        <p class="description">Hosted office hours, advised student projects, and led discussion sections on <a href="http://cs231n.stanford.edu/slides/2018/cs231n_2018_ds02.pdf">backpropogation</a> and <a href="http://cs231n.stanford.edu/slides/2018/cs231n_2018_ds07.pdf">weak supervision</a>.</p>
+        <p class="description">Hosted office hours, advised student projects, and led discussion sections on <a href="http://cs231n.stanford.edu/slides/2018/cs231n_2018_ds02.pdf">backpropagation</a> and <a href="http://cs231n.stanford.edu/slides/2018/cs231n_2018_ds07.pdf">weak supervision</a>.</p>
       </section>
     </div>
 


### PR DESCRIPTION
## Summary
- correct a spelling mistake in the CS231N teaching description

## Testing
- `grep -r "backpropog" -n`

------
https://chatgpt.com/codex/tasks/task_b_684897afa97c8331aef06ba7a6915c6f